### PR TITLE
Migration to new jenkins system

### DIFF
--- a/jenkins/Dockerfile.noble
+++ b/jenkins/Dockerfile.noble
@@ -1,0 +1,41 @@
+FROM ubuntu:noble
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      cmake \
+      g++-14 \
+      gfortran \
+      git \
+      hdf5-tools \
+      meson \
+      ninja-build \
+      libgtest-dev \
+      libboost-dev \
+      libclang-dev \
+      libeigen3-dev \
+      libfftw3-dev \
+      libgfortran5 \
+      libgmp-dev \
+      libgsl-dev \
+      libhdf5-dev \
+      libmpfr-dev \
+      libnfft3-dev \
+      libopenblas-dev \
+      libopenmpi-dev \
+      meson \
+      ninja-build \
+      python3-dev \
+      python3-mako \
+      python3-matplotlib \
+      python3-mpi4py \
+      python3-numpy \
+      python3-pytest \
+      python3-scipy \
+      python3-setuptools \
+      python3-skimage \
+      python3-tomli \
+      \
+      apt-utils \
+      debhelper \
+      dpkg-dev
+
+ENV CC=gcc-14 CXX=g++-14

--- a/jenkins/Dockerfile.noble
+++ b/jenkins/Dockerfile.noble
@@ -6,8 +6,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       gfortran \
       git \
       hdf5-tools \
-      meson \
-      ninja-build \
       libgtest-dev \
       libboost-dev \
       libclang-dev \

--- a/jenkins/Dockerfile.resolute
+++ b/jenkins/Dockerfile.resolute
@@ -6,8 +6,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       gfortran \
       git \
       hdf5-tools \
-      meson \
-      ninja-build \
       libgtest-dev \
       libboost-dev \
       libclang-dev \

--- a/jenkins/Dockerfile.resolute
+++ b/jenkins/Dockerfile.resolute
@@ -1,0 +1,41 @@
+FROM ubuntu:26.04
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      cmake \
+      g++ \
+      gfortran \
+      git \
+      hdf5-tools \
+      meson \
+      ninja-build \
+      libgtest-dev \
+      libboost-dev \
+      libclang-dev \
+      libeigen3-dev \
+      libfftw3-dev \
+      libgfortran5 \
+      libgmp-dev \
+      libgsl-dev \
+      libhdf5-dev \
+      libmpfr-dev \
+      libnfft3-dev \
+      libopenblas-dev \
+      libopenmpi-dev \
+      meson \
+      ninja-build \
+      python3-dev \
+      python3-mako \
+      python3-matplotlib \
+      python3-mpi4py \
+      python3-numpy \
+      python3-pytest \
+      python3-scipy \
+      python3-setuptools \
+      python3-skimage \
+      python3-tomli \
+      \
+      apt-utils \
+      debhelper \
+      dpkg-dev
+
+ENV CC=gcc CXX=g++

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -18,6 +18,7 @@ def packages = [
   "triqs_Nevanlinna",
   "triqs_modest"
 ]
+def allPackages = ["triqs"] + packages
 
 catchError {
   stage("base img") {
@@ -29,34 +30,17 @@ catchError {
     }, checkout: true)
   }
 
-  def buildPkg = { pkg ->
-    def srcDir = WORKSPACE
-    def pkgDir = "$srcDir/$pkg"
-    def buildDir = "$WORKSPACE_TMP/build/$pkg"
-    def installDir = "$WORKSPACE_TMP/install"
+  def buildPkg = { platform, pkg ->
     def args = ""
     if (pkg == "triqs_cthyb") {
       args += " -DMeasureG2=ON"
     }
-    dir(buildDir) {
-      // packaging requries prefix /usr, but we also want to install; rather than rebuilding install into /usr
+    dir("$WORKSPACE_TMP/build/$pkg") {
       sh """
-        cmake $pkgDir -DBUILD_DEBIAN_PACKAGE=1 -DCMAKE_INSTALL_PREFIX=/usr $args
+        cmake $WORKSPACE/$pkg -DBUILD_DEBIAN_PACKAGE=1 -DCMAKE_INSTALL_PREFIX=/usr $args
         make -j\$PARALLEL package
-        mv $pkg-*.deb $srcDir
-        cmake $pkgDir -DBUILD_DEBIAN_PACKAGE=0 -DCMAKE_INSTALL_PREFIX=$installDir $args
-        make -j\$PARALLEL install
       """
-      dir('test') {
-        catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
-          sh """
-            . $installDir/share/$pkg/${pkg}vars.sh
-            cmake $srcDir/test/$pkg
-            make -j\$PARALLEL
-            OPENBLAS_NUM_THREADS=1 make test CTEST_OUTPUT_ON_FAILURE=1
-          """
-        }
-      }
+      stash name: "$platform-$pkg", includes: "$pkg-*.deb"
     }
   }
 
@@ -65,43 +49,45 @@ catchError {
       timeout(time: 2, unit: 'HOURS') {
         runPod(tag: platform) {
           stage("triqs-$platform") {
-            def deb = buildPkg("triqs")
-            stash name: "$platform-triqs", includes: "triqs-*.deb"
+            buildPkg(platform, "triqs")
           }
         }
       }
     } ] }
   }
-  stage("triqs img") {
+
+  def installPkgs = { tag, pkgs ->
     buildImages(platforms.collect { platform ->
-      [ tag: "$platform-triqs",
+      [ tag: "$platform-$tag",
         prep: {
-          unstash name: "$platform-triqs"
           def img = imageName(platform)
+          pkgs.each { pkg ->
+            unstash name: "$platform-$pkg"
+          }
           writeFile(file: "Dockerfile", text:
 """
 FROM $img
-COPY triqs-*.deb /tmp
-RUN dpkg -i /tmp/triqs-*.deb
+COPY *.deb /tmp
+RUN dpkg -i /tmp/*.deb
 """)
         }
       ]
     }, checkout: false)
   }
 
+  stage("triqs img") {
+    installPkgs("triqs", ["triqs"])
+  }
+
   parallel platforms.collectEntries { platform -> [(platform): {
     timeout(time: 3, unit: 'HOURS') {
       runPod(tag: "$platform-triqs") {
         stage("$platform pkgs") {
-          def repo = "$WORKSPACE_TMP/repo"
-          dir (repo) {
-            unstash name: "$platform-triqs"
-          }
-          packages.each { pkg ->
-            buildPkg(pkg)
-            sh "mv $pkg-*.deb $repo"
-          }
-          dir(repo) {
+          packages.each { buildPkg(platform, it) }
+          dir("$WORKSPACE_TMP/repo") {
+            allPackages.each { pkg ->
+              unstash name: "$platform-$pkg"
+            }
             withCredentials([file(credentialsId: 'triqs-packaging-key', variable: 'SECRET')]) {
               sh 'cp $SECRET secret.gpg'
             }
@@ -121,6 +107,30 @@ RUN dpkg -i /tmp/triqs-*.deb
         }
       }
     }
-  } ] }
+  }] }
+
+  stage("pkgs img") {
+    installPkgs("pkgs", allPackages)
+  }
+
+  parallel platforms.collectEntries { platform -> [(platform): {
+    timeout(time: 3, unit: 'HOURS') {
+      runPod(tag: "$platform-pkgs") {
+        stage("$platform tests") {
+          allPackages.each { pkg ->
+            catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
+              dir("$WORKSPACE_TMP/test/$pkg") {
+                sh """
+                  cmake $WORKSPACE/test/$pkg
+                  make -j\$PARALLEL
+                  OPENBLAS_NUM_THREADS=1 make test CTEST_OUTPUT_ON_FAILURE=1
+                """
+              }
+            }
+          }
+        }
+      }
+    }
+  }] }
 }
 emailFailure()

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -9,7 +9,7 @@ def packages = [
   "triqs_cthyb",
   "triqs_ctseg",
   "triqs_dft_tools",
-  "omegamaxent_interface", // missing tests?
+  "omegamaxent_interface",
   "triqs_tprf",
   "triqs_maxent",
   "triqs_hubbardI",

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,126 @@
+properties([
+  disableConcurrentBuilds(),
+  buildDiscarder(logRotator(numToKeepStr: '10', daysToKeepStr: '30'))
+])
+
+def platforms = ["noble", "resolute"]
+def packages = [
+  "triqs_dftkit",
+  "triqs_cthyb",
+  "triqs_ctseg",
+  "triqs_dft_tools",
+  "omegamaxent_interface", // missing tests?
+  "triqs_tprf",
+  "triqs_maxent",
+  "triqs_hubbardI",
+  "triqs_hartree_fock",
+  "solid_dmft",
+  "triqs_Nevanlinna",
+  "triqs_modest"
+]
+
+catchError {
+  stage("base img") {
+    buildImages(platforms.collect { platform ->
+      [ tag: platform,
+        context: 'jenkins',
+        dockerfile: "Dockerfile.$platform"
+      ]
+    }, checkout: true)
+  }
+
+  def buildPkg = { pkg ->
+    def srcDir = WORKSPACE
+    def pkgDir = "$srcDir/$pkg"
+    def buildDir = "$WORKSPACE_TMP/build/$pkg"
+    def installDir = "$WORKSPACE_TMP/install"
+    def args = ""
+    if (pkg == "triqs_cthyb") {
+      args += " -DMeasureG2=ON"
+    }
+    dir(buildDir) {
+      // packaging requries prefix /usr, but we also want to install; rather than rebuilding install into /usr
+      sh """
+        cmake $pkgDir -DBUILD_DEBIAN_PACKAGE=1 -DCMAKE_INSTALL_PREFIX=/usr $args
+        make -j\$PARALLEL package
+        mv $pkg-*.deb $srcDir
+        cmake $pkgDir -DBUILD_DEBIAN_PACKAGE=0 -DCMAKE_INSTALL_PREFIX=$installDir $args
+        make -j\$PARALLEL install
+      """
+      dir('test') {
+        catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
+          sh """
+            . $installDir/share/$pkg/${pkg}vars.sh
+            cmake $srcDir/test/$pkg
+            make -j\$PARALLEL
+            OPENBLAS_NUM_THREADS=1 make test CTEST_OUTPUT_ON_FAILURE=1
+          """
+        }
+      }
+    }
+  }
+
+  stage("triqs pkg") {
+    parallel platforms.collectEntries { platform -> [(platform): {
+      timeout(time: 2, unit: 'HOURS') {
+        runPod(tag: platform) {
+          stage("triqs-$platform") {
+            def deb = buildPkg("triqs")
+            stash name: "$platform-triqs", includes: "triqs-*.deb"
+          }
+        }
+      }
+    } ] }
+  }
+  stage("triqs img") {
+    buildImages(platforms.collect { platform ->
+      [ tag: "$platform-triqs",
+        prep: {
+          unstash name: "$platform-triqs"
+          def img = imageName(platform)
+          writeFile(file: "Dockerfile", text:
+"""
+FROM $img
+COPY triqs-*.deb /tmp
+RUN dpkg -i /tmp/triqs-*.deb
+""")
+        }
+      ]
+    }, checkout: false)
+  }
+
+  parallel platforms.collectEntries { platform -> [(platform): {
+    timeout(time: 3, unit: 'HOURS') {
+      runPod(tag: "$platform-triqs") {
+        stage("$platform pkgs") {
+          def repo = "$WORKSPACE_TMP/repo"
+          dir (repo) {
+            unstash name: "$platform-triqs"
+          }
+          packages.each { pkg ->
+            buildPkg(pkg)
+            sh "mv $pkg-*.deb $repo"
+          }
+          dir(repo) {
+            withCredentials([file(credentialsId: 'triqs-packaging-key', variable: 'SECRET')]) {
+              sh 'cp $SECRET secret.gpg'
+            }
+            sh """
+              cp $WORKSPACE/public.gpg .
+              gpg --import -v -v secret.gpg public.gpg
+              rm secret.gpg
+              apt-ftparchive packages . > Packages
+              gzip -k Packages && bzip2 -k Packages
+              apt-ftparchive release . > release && mv release Release
+              gpg --digest-algo SHA512 --clearsign -o InRelease Release
+              gpg --digest-algo SHA512 -abs -o Release.gpg Release
+              tar czf $WORKSPACE/${platform}.tgz .
+            """
+          }
+          archiveArtifacts(artifacts: "${platform}.tgz")
+        }
+      }
+    }
+  } ] }
+}
+emailFailure()

--- a/test/omegamaxent_interface/CMakeLists.txt
+++ b/test/omegamaxent_interface/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Start configuration
+cmake_minimum_required(VERSION 3.20)
+project(omegamaxent_interface_tests CXX)
+
+# Default to Release build type
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Type of build" FORCE)
+endif()
+message( STATUS "-------- BUILD-TYPE: ${CMAKE_BUILD_TYPE} --------")
+
+#Load Dependencies
+find_package(TRIQS)
+
+enable_testing()
+
+# The Python omegamaxent_interface Tests
+if(${TRIQS_WITH_PYTHON_SUPPORT})
+  add_subdirectory(python)
+endif()

--- a/test/omegamaxent_interface/python
+++ b/test/omegamaxent_interface/python
@@ -1,0 +1,1 @@
+../../omegamaxent_interface/test/python


### PR DESCRIPTION
This mainly restructures to do the builds outside of the image builds, though does add one layer to install the triqns deb package dependency for the other builds.

Everything works except for `omegamaxent_interface` which doesn't have a test directory.  Is this intentional? Should I just have it skip tests for this package, or any package missing a test directory?